### PR TITLE
added

### DIFF
--- a/test
+++ b/test
@@ -1,0 +1,6 @@
+
+Reprise has three separate demo products: Reveal, Replay, and Replicate. Reveal allows you to overlay and customize a live application, whereas Replay captures your full product to share with potential customers.
+
+The most sophisticated of the three, Replicate, clones your application entirely, down to the code level.
+
+Each of these products is sold separately. And while Reprise does not publicly share its pricing, our customers and prospects say the company uses a sliding-scale pricing model based on the number of demos and user seats.


### PR DESCRIPTION
…licate. Reveal allows you to overlay and customize a live application, whereas Replay captures your full product to share with potential customers.

The most sophisticated of the three, Replicate, clones your application entirely, down to the code level.

Each of these products is sold separately. And while Reprise does not publicly share its pricing, our customers and prospects say the company uses a sliding-scale pricing model based on the number of demos and user seats.